### PR TITLE
fix queen side castling issue

### DIFF
--- a/lib/src/game/game.dart
+++ b/lib/src/game/game.dart
@@ -468,7 +468,7 @@ class Game {
               continue;
             } // king starting on target
 
-            if (j != numMidSqs && board[midSq].isNotEmpty) {
+            if (j != numMidSqs && from != midSq && board[midSq].isNotEmpty) {
               // squares between to and from must be empty
               valid = false;
               break;

--- a/lib/src/game/game.dart
+++ b/lib/src/game/game.dart
@@ -468,7 +468,7 @@ class Game {
               continue;
             } // king starting on target
 
-            if (j != numMidSqs && from != midSq && board[midSq].isNotEmpty) {
+            if (j != numMidSqs && midSq != -1 && from != midSq && board[midSq].isNotEmpty) {
               // squares between to and from must be empty
               valid = false;
               break;


### PR DESCRIPTION
Unable to provide queen side castling for `r1bq1rk1/pp2npbp/2np2p1/2p5/4P2P/2NPB1P1/PPP1QPB1/R3K2R w KQq - 0 1` FEN.
At time of calculating valid move for castling it is considering white king piece (E1) as in-between piece of white king (E1) and white queen side rook(A1).
Issue: (https://github.com/alexobviously/bishop/issues/85)